### PR TITLE
Adds support for platform specific monit config directory

### DIFF
--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -61,7 +61,7 @@ node[:deploy].each do |application, deploy|
       end
     end
 
-    template "/etc/monit/conf.d/sidekiq_#{application}.monitrc" do
+    template "#{node[:monit][:conf_dir]}/sidekiq_#{application}.monitrc" do
       mode 0644
       source "sidekiq_monitrc.erb"
       variables({


### PR DESCRIPTION
The OpsWorks cookbook  `opsworks_agent_monit` provides us with platform specific configuration directories attribute for `monit`. 

Making use of this attribute in the setup recipe prevents the following error from occurring

```
================================================================================
Error executing action `create` on resource 'template[/etc/monit/conf.d/sidekiq_my_app.monitrc]'
================================================================================
 
 
Chef::Exceptions::EnclosingDirectoryDoesNotExist
------------------------------------------------
Parent directory /etc/monit/conf.d does not exist.
```

`opsworks_agent_monit` [cookbook reference](https://github.com/aws/opsworks-cookbooks/blob/release-chef-11.4/opsworks_agent_monit/attributes/default.rb)