### PR TITLE
Sets the sidekiq require path

### DIFF
--- a/templates/default/sidekiq_monitrc.erb
+++ b/templates/default/sidekiq_monitrc.erb
@@ -7,7 +7,7 @@
 
 check process sidekiq_<%= identifier %>
   with pidfile <%= pid_file %>
-  start program = "/bin/su - <%= @deploy[:user] %> -c 'cd <%= @deploy[:current_path] %> && RAILS_ENV=<%= @deploy[:rails_env] %> bundle exec sidekiq -C <%= conf_file %> -P  <%= pid_file %> <%= syslog %>'" with timeout 90 seconds
+  start program = "/bin/su - <%= @deploy[:user] %> -c 'cd <%= @deploy[:current_path] %> && RAILS_ENV=<%= @deploy[:rails_env] %> bundle exec sidekiq -C <%= conf_file %> -r <%= @deploy[:current_path] %> -P  <%= pid_file %> <%= syslog %>'" with timeout 90 seconds
   stop  program = "/bin/su - <%= @deploy[:user] %> -c 'kill -s TERM `cat <%= pid_file %>`'" with timeout 90 seconds
   group sidekiq_<%= @application %>_group
 


### PR DESCRIPTION
If we do not set the require path, sidekiq will fail to find views (rendering views for webhooks for example).

This change simply adds the `-r` option