### PR TITLE
Sidekiq does not start with environment variables

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -14,7 +14,7 @@ node[:deploy].each do |application, deploy|
     mode "0660"
     group deploy[:group]
     owner deploy[:user]
-    variables(:database => deploy[:database], :environment => deploy[:rails_env])
+    variables(:database => deploy[:database], :environment => deploy[:rails_env], :deploy => deploy)
 
     notifies :run, resources(:execute => "restart Rails app #{application}")
 

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -1,10 +1,9 @@
 # Adapted from unicorn::rails: https://github.com/aws/opsworks-cookbooks/blob/master/unicorn/recipes/rails.rb
 
-include_recipe "opsworks_sidekiq::service"
+include_recipe 'opsworks_sidekiq::service'
 
 # setup sidekiq service per app
 node[:deploy].each do |application, deploy|
-
   if deploy[:application_type] != 'rails'
     Chef::Log.debug("Skipping opsworks_sidekiq::setup application #{application} as it is not a Rails app")
     next
@@ -23,17 +22,15 @@ node[:deploy].each do |application, deploy|
   # Allow deploy user to restart workers
   template "/etc/sudoers.d/#{deploy[:user]}" do
     mode 0440
-    source "sudoer.erb"
-    variables :user => deploy[:user]
+    source 'sudoer.erb'
+    variables user: deploy[:user]
   end
 
   if node[:sidekiq][application]
-
-    workers = node[:sidekiq][application].to_hash.reject {|k,v| k.to_s =~ /restart_command|syslog/ }
+    workers = node[:sidekiq][application].to_hash.reject { |k, _v| k.to_s =~ /restart_command|syslog/ }
     config_directory = "#{deploy[:deploy_to]}/shared/config"
 
     workers.each do |worker, options|
-
       # Convert attribute classes to plain old ruby objects
       config = options[:config] ? options[:config].to_hash : {}
       config.each do |k, v|
@@ -46,14 +43,14 @@ node[:deploy].each do |application, deploy|
       end
 
       # Generate YAML string
-      yaml = YAML::dump(config)
+      yaml = YAML.dump(config)
 
       # Convert YAML string keys to symbol keys for sidekiq while preserving
       # indentation. (queues: to :queues:)
-      yaml = yaml.gsub(/^(\s*)([^:][^\s]*):/,'\1:\2:')
+      yaml = yaml.gsub(/^(\s*)([^:][^\s]*):/, '\1:\2:')
 
       (options[:process_count] || 1).times do |n|
-        file "#{config_directory}/sidekiq_#{worker}#{n+1}.yml" do
+        file "#{config_directory}/sidekiq_#{worker}#{n + 1}.yml" do
           mode 0644
           action :create
           content yaml
@@ -63,15 +60,13 @@ node[:deploy].each do |application, deploy|
 
     template "#{node[:monit][:conf_dir]}/sidekiq_#{application}.monitrc" do
       mode 0644
-      source "sidekiq_monitrc.erb"
-      variables({
-        :deploy => deploy,
-        :application => application,
-        :workers => workers,
-        :syslog => node[:sidekiq][application][:syslog],
-        environment_variables: OpsWorks::Escape.escape_double_quotes(deploy[:environment_variables])
-      })
-      notifies :reload, resources(:service => "monit"), :immediately
+      source 'sidekiq_monitrc.erb'
+      variables(deploy: deploy,
+                application: application,
+                workers: workers,
+                syslog: node[:sidekiq][application][:syslog],
+                environment_variables: OpsWorks::Escape.escape_double_quotes(deploy[:environment_variables]))
+      notifies :reload, resources(service: 'monit'), :immediately
     end
 
   end

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -68,7 +68,8 @@ node[:deploy].each do |application, deploy|
         :deploy => deploy,
         :application => application,
         :workers => workers,
-        :syslog => node[:sidekiq][application][:syslog]
+        :syslog => node[:sidekiq][application][:syslog],
+        environment_variables: OpsWorks::Escape.escape_double_quotes(deploy[:environment_variables])
       })
       notifies :reload, resources(:service => "monit"), :immediately
     end

--- a/templates/default/sidekiq_monitrc.erb
+++ b/templates/default/sidekiq_monitrc.erb
@@ -4,10 +4,11 @@
   <% conf_file = "#{@deploy[:deploy_to]}/shared/config/sidekiq_#{worker}#{n+1}.yml" %>
   <% pid_file = "#{@deploy[:deploy_to]}/shared/pids/sidekiq_#{identifier}.pid" %>
   <% syslog = @syslog ? "2>&1 | logger -t sidekiq-#{identifier}" : '' %>
+  <% environment_variables = @environment_variables.map{|key, value| "#{key}=#{value}"}.join(" ") %>
 
 check process sidekiq_<%= identifier %>
   with pidfile <%= pid_file %>
-  start program = "/bin/su - <%= @deploy[:user] %> -c 'cd <%= @deploy[:current_path] %> && RAILS_ENV=<%= @deploy[:rails_env] %> bundle exec sidekiq -C <%= conf_file %> -r <%= @deploy[:current_path] %> -P  <%= pid_file %> <%= syslog %>'" with timeout 90 seconds
+  start program = "/bin/su - <%= @deploy[:user] %> -c 'cd <%= @deploy[:current_path] %> && RAILS_ENV=<%= @deploy[:rails_env] %> <%= environment_variables %> bundle exec sidekiq -C <%= conf_file %> -r <%= @deploy[:current_path] %> -P  <%= pid_file %> <%= syslog %>'" with timeout 90 seconds
   stop  program = "/bin/su - <%= @deploy[:user] %> -c 'kill -s TERM `cat <%= pid_file %>`'" with timeout 90 seconds
   group sidekiq_<%= @application %>_group
 

--- a/templates/default/sidekiq_monitrc.erb
+++ b/templates/default/sidekiq_monitrc.erb
@@ -4,7 +4,7 @@
   <% conf_file = "#{@deploy[:deploy_to]}/shared/config/sidekiq_#{worker}#{n+1}.yml" %>
   <% pid_file = "#{@deploy[:deploy_to]}/shared/pids/sidekiq_#{identifier}.pid" %>
   <% syslog = @syslog ? "2>&1 | logger -t sidekiq-#{identifier}" : '' %>
-  <% environment_variables = @environment_variables.map{|key, value| "#{key}=#{value}"}.join(" ") %>
+  <% environment_variables = @environment_variables.map{|key, value| "#{key}='#{value}'"}.join(" ") %>
 
 check process sidekiq_<%= identifier %>
   with pidfile <%= pid_file %>

--- a/templates/default/sidekiq_monitrc.erb
+++ b/templates/default/sidekiq_monitrc.erb
@@ -4,7 +4,7 @@
   <% conf_file = "#{@deploy[:deploy_to]}/shared/config/sidekiq_#{worker}#{n+1}.yml" %>
   <% pid_file = "#{@deploy[:deploy_to]}/shared/pids/sidekiq_#{identifier}.pid" %>
   <% syslog = @syslog ? "2>&1 | logger -t sidekiq-#{identifier}" : '' %>
-  <% environment_variables = @environment_variables.map{|key, value| "#{key}='#{value}'"}.join(" ") %>
+  <% environment_variables = @environment_variables.map{|key, value| "#{key}=\"#{value}\""}.join(" ") %>
 
 check process sidekiq_<%= identifier %>
   with pidfile <%= pid_file %>


### PR DESCRIPTION
Two different apps need env vars but they aren't passed with the start command. There may be a better way but this one is tested in two stacks and it works.

Code originally done by @codeodor.
